### PR TITLE
Migrate example to be compatible with Express 4.x

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -1,4 +1,10 @@
 var express = require('express')
+  , morgan = require('morgan')
+  , cookieParser = require('cookie-parser')
+  , bodyParser = require('body-parser')
+  , methodOverride = require('method-override')
+  , session = require('express-session')
+  , expressLayouts = require('express-ejs-layouts')
   , http = require('http')
   , passport = require('passport')
   , util = require('util')
@@ -10,16 +16,16 @@ var app = express();
 app.set('port', process.env.PORT || 3000);
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
-app.use(express.logger());
-app.use(express.cookieParser());
-app.use(express.bodyParser());
-app.use(express.methodOverride());
-app.use(express.session({ secret: 'keyboard cat' }));
+app.use(morgan('combined'));
+app.use(cookieParser());
+app.use(bodyParser.urlencoded({extended: false}));
+app.use(methodOverride());
+app.use(session({ secret: 'keyboard cat' }));
+app.use(expressLayouts);
 // Initialize Passport!  Also use passport.session() middleware, to support
 // persistent login sessions (recommended).
 app.use(passport.initialize());
 app.use(passport.session());
-app.use(app.router);
 app.use(express.static(__dirname + '/public'));
 
 var XING_API_KEY = "--insert-xing-api-key-here--"

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -4,6 +4,12 @@
   "dependencies": {
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",
+    "express-ejs-layouts": ">= 0.0.0",
+    "body-parser": ">= 0.0.0",
+    "cookie-parser": ">= 0.0.0",
+    "express-session": ">= 0.0.0",
+    "method-override": ">= 0.0.0",
+    "morgan": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-xing": ">= 0.0.0"
   }


### PR DESCRIPTION
I tried to make minimal changes to the example to let it run with Express 4.

I'm not an experienced Express developer and did mostly the steps from the [upgrade guide](https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x).

Currently all packages are bound to depend on version `">= 0.0.0"`. I think that binding them to a more specific version could help in case of future updates. What do you think? If you agree I'd like to fix the current known working versions of each package.
